### PR TITLE
Remove unneeded include

### DIFF
--- a/src/RotaryEncoder.cpp
+++ b/src/RotaryEncoder.cpp
@@ -1,5 +1,4 @@
 #include "RotaryEncoder.h"
-#include "arduino.h"
 
 void RotaryEncoder::init()
 {


### PR DESCRIPTION
Fixes: RotaryEncoder.cpp:2:10: fatal error: arduino.h: No such file or directory