### PR TITLE
Improve the LED signalling for more intuitive use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+
+# PlatformIO
+.pio/
+
+# Visual Studio Code
+.vscode/

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,15 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:leonardo]
+platform = atmelavr
+board = leonardo
+framework = arduino
+monitor_speed = 57600


### PR DESCRIPTION
With this change, the LED:

- Lights steady if the system is on and not emergency stopped
- Blinks at medium speed to indicated that the Rotary encoder is ready to read input
- Blinks at high speed to indicate that input has been received and is processed \*

\* <sub> this is useful to understand that the Pendant is actually working, and if the machine doesn't move, something else must be going on. In my case: panel due port was not activated in configuration and it took me a full firmware debug session to find out 😄  </sub>


This also adds a platformio config for IDE support.